### PR TITLE
Fix: Handle 404 responses for non-existent transcripts

### DIFF
--- a/services/learn.js
+++ b/services/learn.js
@@ -15,12 +15,8 @@ module.exports = class LearnAPI {
             });
             return response.data;
         } catch (error) {
-            console.error(error);
-            return {
-                'code': error.code,
-                'status': error.status,
-                'message': error.message,
-            };
+            console.error(`${error.message} | transcript_id = ${transcript_id}`);
+            throw error;
         }
     }
 
@@ -33,12 +29,8 @@ module.exports = class LearnAPI {
             });
             return response.data;
         } catch (error) {
-            console.error(error);
-            return {
-                'code': error.code,
-                'status': error.status,
-                'message': error.message,
-            };
+            console.error(`${error.message} | module_uid = ${module_uid}`);
+            throw error;
         }
     }
 }


### PR DESCRIPTION
This pull request improves the handling of 404 responses for non-existent transcripts.

While 404 responses were already being handled, the `learn` client returned an object containing `status`, `code`, and `message` keys. However, the consumer was not validating successful responses from the `learn` client and attempted to access undefined keys in the response object.